### PR TITLE
Improve version handling in publish-maven workflow

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -36,19 +36,26 @@ jobs:
         run: |
           echo "ref_type=${{ github.ref_type }}"
           echo "ref_name=${GITHUB_REF_NAME}"
+
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"   # strip leading 'v'
+            # Tag case, e.g. refs/tags/v1.2.3
+            VERSION="${GITHUB_REF_NAME#v}"     # strip leading 'v' if present
+            VERSION="${VERSION#V}"             # strip leading 'V' if present
           elif [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+            # Manual input; accept either 1.2.3 or v1.2.3
+            RAW="${{ github.event.inputs.version }}"
+            RAW="$(echo "$RAW" | tr -d '[:space:]')"   # trim spaces
+            VERSION="${RAW#v}"
+            VERSION="${VERSION#V}"
           else
-            BASE=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
-            # fallback: trim possible noise
-            BASE=$(printf "%s" "$BASE" | tail -n1)
+            # Push to main: derive from pom; ensure SNAPSHOT
+            BASE=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version | tail -n1)
             case "$BASE" in
               *-SNAPSHOT) VERSION="$BASE" ;;
               *)          VERSION="${BASE}-SNAPSHOT" ;;
             esac
           fi
+
           echo "Computed VERSION=$VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -56,9 +63,7 @@ jobs:
       - name: Validate version (SemVer-ish)
         shell: bash
         run: |
-          # Accept: MAJOR.MINOR.PATCH
-          # Optional: -pre.release.with.dots or -SNAPSHOT
-          # Optional: +build.meta
+          # Accept MAJOR.MINOR.PATCH with optional -prerelease (incl. SNAPSHOT) and optional +build
           if ! echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z.-]+)?$'; then
             echo "Invalid version: $VERSION"
             exit 1


### PR DESCRIPTION
Enhanced version extraction logic to handle both 'v' and 'V' prefixes. Updated version validation to accept optional prerelease and build metadata.