### PR TITLE
Add MATCH_RECOGNIZE transpilation diagnostics and codegen

### DIFF
--- a/docs/codegen/SQL_FILE_CODEGEN_DRAFT.md
+++ b/docs/codegen/SQL_FILE_CODEGEN_DRAFT.md
@@ -137,6 +137,24 @@ public final class UserQueries {
 - Stable formatting (fixed indentation and import sorting).
 - Output only changes when input SQL/config changes.
 
+## Row-Pattern Recognition
+
+Oracle SQL files containing `MATCH_RECOGNIZE` generate typed public DSL and
+builder calls for the complete modeled family:
+
+- relation options, measures, definitions, subsets, row-output modes, and
+  after-match skip positions;
+- variables, sequences, alternations, permutations, anchors, empty patterns,
+  exclusions, and greedy or reluctant quantifiers;
+- pattern columns, `CLASSIFIER`, `MATCH_NUMBER`, navigation functions, and
+  running/final evaluation.
+
+Generated source preserves quoted identifiers and explicit semantic options.
+It never instantiates `Impl` classes, embeds raw pattern SQL, or replaces typed
+pattern expressions with generic function calls. Golden tests cover compact,
+full-pattern, and expression-heavy Oracle inputs; compile the generated Java;
+reconstruct equal semantic trees; and render equivalent Oracle SQL.
+
 ## Maven Plugin Draft
 
 ### Coordinates

--- a/docs/epics/R11_8_MATCH_RECOGNIZE_DESIGN.md
+++ b/docs/epics/R11_8_MATCH_RECOGNIZE_DESIGN.md
@@ -1,7 +1,7 @@
 # R11-8 SQL Row Pattern Recognition (`MATCH_RECOGNIZE`) Design
 
-**Status:** Detailed design complete; R11-8A through R11-8C implemented, with
-transpilation, codegen, and live-engine coverage remaining in R11-8D and R11-8E.
+**Status:** Detailed design complete; R11-8A through R11-8D implemented, with
+live-engine coverage and epic completion remaining in R11-8E.
 
 **Primary delivery target:** Oracle 12.1+.
 

--- a/docs/model/MODEL.md
+++ b/docs/model/MODEL.md
@@ -740,7 +740,7 @@ graph TD
   ANSI explicitly rejects this node, and other dialects do not currently ship parser or renderer support for it.
 
 - **PatternRecognitionTable**
-  Shared relation transform for SQL row-pattern recognition. It stores a source relation, optional partitioning and ordering, named measures, output-cardinality and after-match behavior, a typed `MatchPattern`, subsets, definitions, and an optional result alias. The shared model is implemented independently of dialect syntax; Oracle 12.1+ parser, renderer, validation, and live-engine support are delivered by the remaining R11-8 stories.
+  Shared relation transform for SQL row-pattern recognition. It stores a source relation, optional partitioning and ordering, named measures, output-cardinality and after-match behavior, a typed `MatchPattern`, subsets, definitions, and an optional result alias. The shared model is implemented independently of dialect syntax. Oracle 12.1+ parsing, rendering, validation, DSL code generation, and exact Oracle-to-Oracle transpilation are implemented; non-Oracle targets receive an explicit path-aware unsupported diagnostic. Broad live-engine coverage remains in R11-8E.
 
 - **MatchPattern**
   Sealed typed grammar family for primary variables, sequences, alternations, permutations, anchors, empty patterns, exclusions, and greedy or reluctant quantifiers. Parentheses used only for precedence are not persisted, and no variant stores raw SQL.

--- a/docs/transpilation/SQL_TRANSPILATION_DESIGN.md
+++ b/docs/transpilation/SQL_TRANSPILATION_DESIGN.md
@@ -1229,6 +1229,16 @@ Examples include:
 - dialect-specific JSON/operator families
 - planner or execution semantics that are not just syntax differences
 
+`MATCH_RECOGNIZE` is handled by a global capability rejection rule. The rule
+locates every `PatternRecognitionTable`, including relations nested in queries,
+joins, CTEs, and DML query sources. Oracle-to-Oracle is currently the only exact
+native pair. Every other current pair reports `UNSUPPORTED_MATCH_RECOGNIZE`
+with a stable semantic relation path. The rule exposes an exact-compatibility
+predicate for future native dialect implementations so all modeled pattern,
+row-output, skip, subset, exclusion, navigation, and evaluation options can be
+checked before exact pass-through is enabled. No approximate rewrite is
+performed.
+
 ## Current Slice Backlog And Limitations
 
 For the current PostgreSQL -> MySQL slice, the following items remain intentionally out of scope or only partially covered and should stay visible as follow-up backlog:
@@ -1271,6 +1281,7 @@ The current initial transpilation slice should stay explicit about what is exact
 | Unsupported | Oracle hierarchical queries targeting SQL Server   | Rejected with `UNSUPPORTED_HIERARCHICAL_QUERY`                                           | SQL Server recursive CTE rendering does not use `WITH RECURSIVE` and needs a dedicated renderer/model story                            |
 | Approximate | Simple Oracle/SQL Server `PIVOT` / `UNPIVOT`       | Rewritten to conditional aggregation or `UNION ALL` for PostgreSQL/MySQL/ANSI targets    | Requires `allowApproximateRewrites`; limited to explicit top-level projections and conservative query shapes                           |
 | Unsupported | Complex Oracle/SQL Server `PIVOT` / `UNPIVOT`      | Rejected with `UNSUPPORTED_PIVOT_UNPIVOT_REWRITE`                                        | Nested transforms, star projections, multiple pivot measures, and surrounding clauses need separate lowering rules                     |
+| Unsupported | Oracle `MATCH_RECOGNIZE` to a non-Oracle target     | Rejected with `UNSUPPORTED_MATCH_RECOGNIZE` and a stable relation path                    | No approximate lowering; future native targets must pass the full exact-compatibility check                                               |
 
 ### MySQL -> PostgreSQL
 

--- a/docs/transpilation/SQL_TRANSPILATION_USAGE.md
+++ b/docs/transpilation/SQL_TRANSPILATION_USAGE.md
@@ -164,6 +164,7 @@ combined render result and `result.params()` preserves statement order.
   - Oracle statement and table hints are dropped for non-Oracle targets
   - simple top-level `PIVOT`/`UNPIVOT` transforms are rewritten approximately to conditional aggregation or `UNION ALL` for PostgreSQL/MySQL/ANSI targets when `allowApproximateRewrites` is enabled
 - Unsupported:
+  - `MATCH_RECOGNIZE` is rejected with `UNSUPPORTED_MATCH_RECOGNIZE`; the problem includes a stable relation path such as `select.matchRecognize[0]`
   - Oracle DML `RETURNING ... INTO` is modeled and parsed, but exact transpilation to non-Oracle result channels is unsupported until an explicit conversion rule is designed
   - Complex Oracle hierarchical queries, including `NOCYCLE`, `ORDER SIBLINGS BY`, joins, grouping, pagination, locking, or non-column projections, are rejected with `UNSUPPORTED_HIERARCHICAL_QUERY_REWRITE`
   - complex or nested `PIVOT`/`UNPIVOT` shapes are rejected with `UNSUPPORTED_PIVOT_UNPIVOT_REWRITE`
@@ -193,6 +194,7 @@ combined render result and `result.params()` preserves statement order.
 | Oracle                | SQL Server            | limit-only row limiting                   | Exact rewrite to `TOP`                                                    |
 | Oracle                | non-Oracle            | hints                                     | Approximate drop with `ORACLE_HINTS_DROPPED`                              |
 | Oracle                | non-Oracle            | `RETURNING ... INTO`                      | Unsupported with `UNSUPPORTED_ORACLE_RETURNING_INTO`                      |
+| Oracle                | non-Oracle            | `MATCH_RECOGNIZE`                         | Unsupported with `UNSUPPORTED_MATCH_RECOGNIZE` and a relation path        |
 | Oracle                | PostgreSQL/MySQL/ANSI | simple hierarchical query (`CONNECT BY`)  | Exact rewrite to recursive CTE                                            |
 | Oracle                | PostgreSQL/MySQL/ANSI | complex hierarchical query (`CONNECT BY`) | Unsupported with `UNSUPPORTED_HIERARCHICAL_QUERY_REWRITE`                 |
 | Oracle/SQL Server     | PostgreSQL/MySQL/ANSI | simple top-level `PIVOT` / `UNPIVOT`      | Approximate rewrite with `APPROXIMATE_PIVOT_UNPIVOT_REWRITE` when enabled |
@@ -229,6 +231,13 @@ Use:
 - `result.problems()` for blocking issues
 - `result.warnings()` for non-blocking rewrites or dropped behavior
 - `result.steps()` for the ordered rule trace
+
+For `MATCH_RECOGNIZE`, `problem.clausePath()` identifies the unsupported
+relation even when it is nested in a subquery, join, CTE, or DML query source.
+Oracle-to-Oracle transpilation passes the complete modeled clause through
+exactly. Other current targets are rejected before rendering because SQM does
+not approximate row-pattern semantics with windows, joins, recursive CTEs, or
+procedural SQL.
 
 SQL Server note:
 

--- a/sqm-codegen/pom.xml
+++ b/sqm-codegen/pom.xml
@@ -82,6 +82,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.sqm</groupId>
+            <artifactId>sqm-render-oracle</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/sqm-codegen/src/main/java/io/sqm/codegen/SqmDslVisitor.java
+++ b/sqm-codegen/src/main/java/io/sqm/codegen/SqmDslVisitor.java
@@ -883,6 +883,247 @@ final class SqmDslVisitor extends RecursiveNodeVisitor<Void> {
     }
 
     @Override
+    public Void visitPatternRecognitionTable(PatternRecognitionTable table) {
+        out.append("matchRecognize(");
+        appendNode(table.source());
+        out.append(")").in();
+        if (table.partitionBy() != null) {
+            out.nl().append(".partitionBy(");
+            appendNode(table.partitionBy());
+            out.append(")");
+        }
+        if (table.orderBy() != null) {
+            out.nl().append(".orderBy(");
+            appendNode(table.orderBy());
+            out.append(")");
+        }
+        for (var measure : table.measures()) {
+            out.nl().append(".measure(");
+            appendNode(measure);
+            out.append(")");
+        }
+        out.nl().append(".rowsPerMatch(");
+        appendNode(table.rowsPerMatch());
+        out.append(")");
+        out.nl().append(".afterMatchSkip(");
+        appendNode(table.afterMatchSkip());
+        out.append(")");
+        out.nl().append(".pattern(");
+        appendNode(table.pattern());
+        out.append(")");
+        for (var subset : table.subsets()) {
+            out.nl().append(".subset(");
+            appendNode(subset);
+            out.append(")");
+        }
+        for (var definition : table.definitions()) {
+            out.nl().append(".define(");
+            appendNode(definition);
+            out.append(")");
+        }
+        if (table.alias() != null) {
+            out.nl().append(".as(");
+            appendIdentifier(table.alias());
+            out.append(")");
+        }
+        out.nl().append(".build()").out();
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternMeasure(PatternMeasure measure) {
+        out.append("patternMeasure(");
+        appendNode(measure.expression());
+        out.append(", ");
+        appendIdentifier(measure.alias());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternDefinition(PatternDefinition definition) {
+        out.append("patternDefinition(");
+        appendIdentifier(definition.variable());
+        out.append(", ");
+        appendNode(definition.condition());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternSubset(PatternSubset subset) {
+        out.append("patternSubset(");
+        appendIdentifier(subset.name());
+        if (!subset.variables().isEmpty()) {
+            out.append(", ").comma(subset.variables(), this::appendIdentifier);
+        }
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitRowsPerMatch(RowsPerMatch rowsPerMatch) {
+        if (rowsPerMatch.mode() == RowsPerMatch.Mode.ONE) {
+            out.append("oneRowPerMatch()");
+        }
+        else if (rowsPerMatch.emptyMatchHandling() == RowsPerMatch.EmptyMatchHandling.DEFAULT) {
+            out.append("allRowsPerMatch()");
+        }
+        else {
+            out.append("allRowsPerMatch(RowsPerMatch.EmptyMatchHandling.")
+                .append(rowsPerMatch.emptyMatchHandling().name())
+                .append(")");
+        }
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitAfterMatchSkip(AfterMatchSkip afterMatchSkip) {
+        switch (afterMatchSkip.kind()) {
+            case PAST_LAST_ROW -> out.append("skipPastLastRow()");
+            case TO_NEXT_ROW -> out.append("skipToNextRow()");
+            case TO_VARIABLE -> {
+                var helper = switch (afterMatchSkip.position()) {
+                    case DEFAULT -> "skipToPattern";
+                    case FIRST -> "skipToFirst";
+                    case LAST -> "skipToLast";
+                };
+                out.append(helper).append("(");
+                appendIdentifier(afterMatchSkip.variable());
+                out.append(")");
+            }
+        }
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternVariable(MatchPattern.Variable pattern) {
+        out.append("patternVar(");
+        appendIdentifier(pattern.name());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternSequence(MatchPattern.Sequence pattern) {
+        out.append("patternSequence(").comma(pattern.elements(), this::appendNode).append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternAlternation(MatchPattern.Alternation pattern) {
+        out.append("patternAlternation(").comma(pattern.alternatives(), this::appendNode).append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternPermutation(MatchPattern.Permutation pattern) {
+        out.append("patternPermute(").comma(pattern.elements(), this::appendNode).append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternAnchor(MatchPattern.Anchor pattern) {
+        out.append(pattern.kind() == MatchPattern.Anchor.Kind.START ? "patternStart()" : "patternEnd()");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitEmptyPattern(MatchPattern.Empty pattern) {
+        out.append("emptyPattern()");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternExclusion(MatchPattern.Exclusion pattern) {
+        out.append("excludePattern(");
+        appendNode(pattern.pattern());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitQuantifiedPattern(MatchPattern.Quantified pattern) {
+        if (!pattern.reluctant() && pattern.minimum() == 0 && pattern.maximum() == null) {
+            out.append("zeroOrMore(");
+            appendNode(pattern.pattern());
+            out.append(")");
+            return defaultResult();
+        }
+        if (!pattern.reluctant() && pattern.minimum() == 1 && pattern.maximum() == null) {
+            out.append("oneOrMore(");
+            appendNode(pattern.pattern());
+            out.append(")");
+            return defaultResult();
+        }
+        if (!pattern.reluctant() && pattern.minimum() == 0 && pattern.maximum() != null
+            && pattern.maximum() == 1) {
+            out.append("optionalPattern(");
+            appendNode(pattern.pattern());
+            out.append(")");
+            return defaultResult();
+        }
+        out.append("repeatPattern(");
+        appendNode(pattern.pattern());
+        out.append(", ").append(String.valueOf(pattern.minimum())).append(", ");
+        out.append(pattern.maximum() == null ? "null" : String.valueOf(pattern.maximum()));
+        out.append(", ").append(String.valueOf(pattern.reluctant())).append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternColumnExpr(PatternColumnExpr expression) {
+        out.append("patternColumn(");
+        appendIdentifier(expression.variable());
+        out.append(", ");
+        appendIdentifier(expression.column());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitClassifierExpr(ClassifierExpr expression) {
+        out.append("classifier(");
+        if (expression.variable() != null) {
+            appendIdentifier(expression.variable());
+        }
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitMatchNumberExpr(MatchNumberExpr expression) {
+        out.append("matchNumber()");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternNavigationExpr(PatternNavigationExpr expression) {
+        var helper = switch (expression.kind()) {
+            case FIRST -> "first";
+            case LAST -> "last";
+            case PREV -> "prev";
+            case NEXT -> "next";
+        };
+        out.append(helper).append("(");
+        appendNode(expression.expression());
+        if (expression.offset() != null) {
+            out.append(", ");
+            appendNode(expression.offset());
+        }
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
+    public Void visitPatternEvaluationExpr(PatternEvaluationExpr expression) {
+        out.append(expression.mode() == PatternEvaluationExpr.Mode.RUNNING ? "running(" : "finalValue(");
+        appendNode(expression.expression());
+        out.append(")");
+        return defaultResult();
+    }
+
+    @Override
     public Void visitLateral(Lateral l) {
         appendNode(l.inner());
         out.append(".lateral()");

--- a/sqm-codegen/src/test/java/io/sqm/codegen/MatchRecognizeCodegenTest.java
+++ b/sqm-codegen/src/test/java/io/sqm/codegen/MatchRecognizeCodegenTest.java
@@ -1,0 +1,283 @@
+package io.sqm.codegen;
+
+import io.sqm.core.AfterMatchSkip;
+import io.sqm.core.Query;
+import io.sqm.core.QuoteStyle;
+import io.sqm.core.RowsPerMatch;
+import io.sqm.parser.oracle.spi.OracleSpecs;
+import io.sqm.parser.spi.ParseContext;
+import io.sqm.render.oracle.spi.OracleDialect;
+import io.sqm.render.spi.RenderContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static io.sqm.dsl.Dsl.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchRecognizeCodegenTest {
+    private static final String COMPACT_SQL = """
+        SELECT *
+        FROM sales MATCH_RECOGNIZE (
+          PATTERN (A)
+          DEFINE A AS A.amount > 0
+        ) mr
+        """;
+
+    private static final String FULL_PATTERN_SQL = """
+        SELECT *
+        FROM sales MATCH_RECOGNIZE (
+          PARTITION BY customer_id
+          ORDER BY sale_date
+          ALL ROWS PER MATCH
+          AFTER MATCH SKIP TO FIRST B
+          PATTERN (^ PERMUTE(A, B) (C | D)* {- E+ -} () F? G{2,4}? $)
+          SUBSET U = (A, B)
+          DEFINE A AS A.amount > 0,
+                 B AS B.amount > 0,
+                 C AS C.amount > 0,
+                 D AS D.amount > 0,
+                 E AS E.amount > 0,
+                 F AS F.amount > 0,
+                 G AS G.amount > 0
+        ) mr
+        """;
+
+    private static final String EXPRESSION_HEAVY_SQL = """
+        SELECT *
+        FROM sales MATCH_RECOGNIZE (
+          MEASURES MATCH_NUMBER() AS match_no,
+                   CLASSIFIER() AS label,
+                   CLASSIFIER(A) AS a_label,
+                   FIRST(A.amount) AS first_amount,
+                   FINAL LAST(B.amount, 1) AS last_amount,
+                   RUNNING PREV(B.amount, 2) AS previous_amount,
+                   NEXT(B.amount, 1) AS next_amount
+          ONE ROW PER MATCH
+          AFTER MATCH SKIP TO NEXT ROW
+          PATTERN (A B+?)
+          DEFINE A AS A.amount > 0,
+                 B AS B.amount > PREV(B.amount)
+        ) mr
+        """;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void emitsCompactGoldenDsl() {
+        assertEquals("""
+            select(
+                star()
+            )
+            .from(matchRecognize(tbl("sales"))
+                .rowsPerMatch(oneRowPerMatch())
+                .afterMatchSkip(skipPastLastRow())
+                .pattern(patternVar(id("A")))
+                .define(patternDefinition(id("A"), patternColumn(id("A"), id("amount")).gt(lit(0L))))
+                .as(id("mr"))
+                .build())
+            .build()""", new SqmJavaEmitter().emit(parse(COMPACT_SQL)));
+    }
+
+    @Test
+    void emitsFullPatternGoldenDsl() {
+        assertEquals("""
+            select(
+                star()
+            )
+            .from(matchRecognize(tbl("sales"))
+                .partitionBy(partition(col("customer_id")))
+                .orderBy(orderBy(col("sale_date")))
+                .rowsPerMatch(allRowsPerMatch())
+                .afterMatchSkip(skipToFirst(id("B")))
+                .pattern(patternSequence(patternStart(), patternPermute(patternVar(id("A")), patternVar(id("B"))), zeroOrMore(patternAlternation(patternVar(id("C")), patternVar(id("D")))), excludePattern(oneOrMore(patternVar(id("E")))), emptyPattern(), optionalPattern(patternVar(id("F"))), repeatPattern(patternVar(id("G")), 2, 4, true), patternEnd()))
+                .subset(patternSubset(id("U"), id("A"), id("B")))
+                .define(patternDefinition(id("A"), patternColumn(id("A"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("B"), patternColumn(id("B"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("C"), patternColumn(id("C"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("D"), patternColumn(id("D"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("E"), patternColumn(id("E"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("F"), patternColumn(id("F"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("G"), patternColumn(id("G"), id("amount")).gt(lit(0L))))
+                .as(id("mr"))
+                .build())
+            .build()""", new SqmJavaEmitter().emit(parse(FULL_PATTERN_SQL)));
+    }
+
+    @Test
+    void emitsExpressionHeavyGoldenDsl() {
+        assertEquals("""
+            select(
+                star()
+            )
+            .from(matchRecognize(tbl("sales"))
+                .measure(patternMeasure(matchNumber(), id("match_no")))
+                .measure(patternMeasure(classifier(), id("label")))
+                .measure(patternMeasure(classifier(id("A")), id("a_label")))
+                .measure(patternMeasure(first(patternColumn(id("A"), id("amount"))), id("first_amount")))
+                .measure(patternMeasure(finalValue(last(patternColumn(id("B"), id("amount")), lit(1L))), id("last_amount")))
+                .measure(patternMeasure(running(prev(patternColumn(id("B"), id("amount")), lit(2L))), id("previous_amount")))
+                .measure(patternMeasure(next(patternColumn(id("B"), id("amount")), lit(1L)), id("next_amount")))
+                .rowsPerMatch(oneRowPerMatch())
+                .afterMatchSkip(skipToNextRow())
+                .pattern(patternSequence(patternVar(id("A")), repeatPattern(patternVar(id("B")), 1, null, true)))
+                .define(patternDefinition(id("A"), patternColumn(id("A"), id("amount")).gt(lit(0L))))
+                .define(patternDefinition(id("B"), patternColumn(id("B"), id("amount")).gt(prev(patternColumn(id("B"), id("amount"))))))
+                .as(id("mr"))
+                .build())
+            .build()""", new SqmJavaEmitter().emit(parse(EXPRESSION_HEAVY_SQL)));
+    }
+
+    @Test
+    void emitsEveryRowsAndVariableSkipOptionWithQuotedIdentifiers() {
+        assertEquals(
+            "allRowsPerMatch(RowsPerMatch.EmptyMatchHandling.SHOW_EMPTY)",
+            emittedOption(
+                RowsPerMatch.EmptyMatchHandling.SHOW_EMPTY,
+                skipToPattern(id("A B", QuoteStyle.DOUBLE_QUOTE)),
+                "skipToPattern(id(\"A B\", QuoteStyle.DOUBLE_QUOTE))"
+            )
+        );
+        assertEquals(
+            "allRowsPerMatch(RowsPerMatch.EmptyMatchHandling.OMIT_EMPTY)",
+            emittedOption(
+                RowsPerMatch.EmptyMatchHandling.OMIT_EMPTY,
+                skipToLast(id("A B", QuoteStyle.DOUBLE_QUOTE)),
+                "skipToLast(id(\"A B\", QuoteStyle.DOUBLE_QUOTE))"
+            )
+        );
+        assertEquals(
+            "allRowsPerMatch(RowsPerMatch.EmptyMatchHandling.WITH_UNMATCHED)",
+            emittedOption(
+                RowsPerMatch.EmptyMatchHandling.WITH_UNMATCHED,
+                skipToFirst(id("A B", QuoteStyle.DOUBLE_QUOTE)),
+                "skipToFirst(id(\"A B\", QuoteStyle.DOUBLE_QUOTE))"
+            )
+        );
+    }
+
+    @Test
+    void generatedOracleDslCompilesAndReconstructsEquivalentTreesAndSql() throws Exception {
+        var sqlDir = tempDir.resolve("sql");
+        var outDir = tempDir.resolve("generated");
+        var fixtures = new LinkedHashMap<String, String>();
+        fixtures.put("compact", COMPACT_SQL);
+        fixtures.put("full_pattern", FULL_PATTERN_SQL);
+        fixtures.put("expression_heavy", EXPRESSION_HEAVY_SQL);
+        for (var fixture : fixtures.entrySet()) {
+            var path = sqlDir.resolve("match/" + fixture.getKey() + ".sql");
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, fixture.getValue(), StandardCharsets.UTF_8);
+        }
+
+        var options = SqlFileCodegenOptions.of(
+            sqlDir,
+            outDir,
+            "io.sqm.codegen.generated",
+            SqlCodegenDialect.ORACLE
+        );
+        var generated = SqlFileCodeGenerator.of(options).generate();
+        var classes = compile(generated, tempDir.resolve("classes"));
+
+        try (var loader = URLClassLoader.newInstance(
+            new URL[]{classes.toUri().toURL()}, getClass().getClassLoader())) {
+            for (var fixture : fixtures.entrySet()) {
+                var expected = parse(fixture.getValue());
+                var actual = invoke(loader, NameNormalizer.toMethodName(fixture.getKey()));
+                assertEquals(expected, actual, "Generated tree mismatch for " + fixture.getKey());
+                assertEquals(
+                    normalizeSql(render(expected)),
+                    normalizeSql(render(actual)),
+                    "Generated Oracle SQL mismatch for " + fixture.getKey()
+                );
+            }
+        }
+    }
+
+    private static Query parse(String sql) {
+        var result = ParseContext.of(new OracleSpecs()).parse(Query.class, sql);
+        assertTrue(result.ok(), result.errorMessage());
+        return result.value();
+    }
+
+    private static String emittedOption(
+        RowsPerMatch.EmptyMatchHandling handling,
+        AfterMatchSkip skip,
+        String expectedSkip
+    ) {
+        var quoted = id("A B", QuoteStyle.DOUBLE_QUOTE);
+        var statement = select(star())
+            .from(matchRecognize(tbl("sales"))
+                .rowsPerMatch(allRowsPerMatch(handling))
+                .afterMatchSkip(skip)
+                .pattern(patternVar(quoted))
+                .define(patternDefinition(quoted, patternColumn(quoted, id("amount")).gt(lit(0L))))
+                .as(id("Result Alias", QuoteStyle.DOUBLE_QUOTE))
+                .build())
+            .build();
+        var emitted = new SqmJavaEmitter().emit(statement);
+
+        assertTrue(emitted.contains(".afterMatchSkip(" + expectedSkip + ")"));
+        assertTrue(emitted.contains(".pattern(patternVar(id(\"A B\", QuoteStyle.DOUBLE_QUOTE)))"));
+        assertTrue(emitted.contains(".as(id(\"Result Alias\", QuoteStyle.DOUBLE_QUOTE))"));
+        assertFalse(emitted.contains(".Impl"));
+        return emitted.lines()
+            .map(String::trim)
+            .filter(line -> line.startsWith(".rowsPerMatch("))
+            .map(line -> line.substring(".rowsPerMatch(".length(), line.length() - 1))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private static String render(Query query) {
+        return RenderContext.of(new OracleDialect()).render(query).sql();
+    }
+
+    private static String normalizeSql(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+
+    private static Path compile(List<Path> sources, Path classes) throws Exception {
+        var compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "JDK compiler is required for generated DSL tests");
+        Files.createDirectories(classes);
+        var diagnostics = new DiagnosticCollector<JavaFileObject>();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(
+            diagnostics, null, StandardCharsets.UTF_8)) {
+            var units = fileManager.getJavaFileObjectsFromPaths(sources);
+            var success = compiler.getTask(
+                null,
+                fileManager,
+                diagnostics,
+                List.of("-classpath", System.getProperty("java.class.path"), "-d", classes.toString()),
+                null,
+                units
+            ).call();
+            assertEquals(Boolean.TRUE, success, "Generated DSL failed to compile: " + diagnostics.getDiagnostics());
+        }
+        return classes;
+    }
+
+    private static Query invoke(ClassLoader loader, String methodName) throws Exception {
+        try {
+            var generatedClass = Class.forName("io.sqm.codegen.generated.MatchQueries", true, loader);
+            return assertInstanceOf(Query.class, generatedClass.getMethod(methodName).invoke(null));
+        }
+        catch (InvocationTargetException ex) {
+            throw new IllegalStateException("Generated method failed: " + methodName, ex.getTargetException());
+        }
+    }
+}

--- a/sqm-playground-rest/src/main/java/io/sqm/playground/rest/example/ExampleCatalog.java
+++ b/sqm-playground-rest/src/main/java/io/sqm/playground/rest/example/ExampleCatalog.java
@@ -162,6 +162,28 @@ public final class ExampleCatalog {
                 WHERE m.active = 1
                 ORDER BY p.region
                 """
+            ),
+            new ExampleDto(
+                "oracle-match-recognize",
+                "Oracle MATCH_RECOGNIZE",
+                SqlDialectDto.oracle,
+                """
+                SELECT *
+                FROM sales MATCH_RECOGNIZE (
+                    PARTITION BY customer_id
+                    ORDER BY sale_date
+                    MEASURES
+                        MATCH_NUMBER() AS match_no,
+                        FIRST(A.amount) AS first_amount,
+                        LAST(B.amount) AS last_amount
+                    ONE ROW PER MATCH
+                    AFTER MATCH SKIP TO NEXT ROW
+                    PATTERN (A B+)
+                    DEFINE
+                        A AS A.amount > 0,
+                        B AS B.amount > PREV(B.amount)
+                ) mr
+                """
             )
         );
     }

--- a/sqm-playground-rest/src/test/java/io/sqm/playground/rest/ExampleServiceTest.java
+++ b/sqm-playground-rest/src/test/java/io/sqm/playground/rest/ExampleServiceTest.java
@@ -26,7 +26,7 @@ class ExampleServiceTest {
         assertTrue(response.success());
         assertNotNull(response.requestId());
         assertFalse(response.requestId().isBlank());
-        assertEquals(11, response.examples().size());
+        assertEquals(12, response.examples().size());
         assertEquals("basic-select", response.examples().getFirst().id());
         assertEquals("ansi", response.examples().getFirst().dialect().name());
         assertTrue(response.examples().stream().anyMatch(example -> example.id().equals("ansi-analytics-report")));
@@ -36,6 +36,7 @@ class ExampleServiceTest {
         assertTrue(response.examples().stream().anyMatch(example -> example.id().equals("oracle-offset-fetch")));
         assertTrue(response.examples().stream().anyMatch(example -> example.id().equals("oracle-hierarchical-query")));
         assertTrue(response.examples().stream().anyMatch(example -> example.id().equals("oracle-pivot-query")));
+        assertTrue(response.examples().stream().anyMatch(example -> example.id().equals("oracle-match-recognize")));
     }
 
     @Test
@@ -53,5 +54,22 @@ class ExampleServiceTest {
 
         assertEquals(TranspileStatus.SUCCESS, result.status());
         assertTrue(result.sql().orElseThrow().contains("WITH RECURSIVE"));
+    }
+
+    @Test
+    void oracleMatchRecognizeExampleParsesValidatesAndRenders() {
+        var example = new ExampleCatalog().examples().stream()
+            .filter(item -> item.id().equals("oracle-match-recognize"))
+            .findFirst()
+            .orElseThrow();
+
+        var result = SqlTranspiler.builder()
+            .sourceDialect(SqlDialectId.ORACLE)
+            .targetDialect(SqlDialectId.ORACLE)
+            .build()
+            .transpile(example.sql());
+
+        assertEquals(TranspileStatus.SUCCESS, result.status());
+        assertTrue(result.sql().orElseThrow().contains("MATCH_RECOGNIZE"));
     }
 }

--- a/sqm-playground-rest/src/test/java/io/sqm/playground/rest/ExamplesControllerIntegrationTest.java
+++ b/sqm-playground-rest/src/test/java/io/sqm/playground/rest/ExamplesControllerIntegrationTest.java
@@ -40,7 +40,7 @@ class ExamplesControllerIntegrationTest {
         assertTrue(response.getBody().success());
         assertNotNull(response.getBody().requestId());
         assertFalse(response.getBody().requestId().isBlank());
-        assertEquals(11, response.getBody().examples().size());
+        assertEquals(12, response.getBody().examples().size());
         assertEquals("basic-select", response.getBody().examples().getFirst().id());
         assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("ansi-analytics-report")));
         assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("postgres-merge-returning")));
@@ -49,5 +49,6 @@ class ExamplesControllerIntegrationTest {
         assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("oracle-offset-fetch")));
         assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("oracle-hierarchical-query")));
         assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("oracle-pivot-query")));
+        assertTrue(response.getBody().examples().stream().anyMatch(example -> example.id().equals("oracle-match-recognize")));
     }
 }

--- a/sqm-transpile/src/main/java/io/sqm/transpile/DefaultSqlTranspiler.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/DefaultSqlTranspiler.java
@@ -90,7 +90,16 @@ public final class DefaultSqlTranspiler implements SqlTranspiler {
     private static List<TranspileProblem> validationProblems(List<io.sqm.validate.api.ValidationProblem> validationProblems) {
         var problems = new ArrayList<TranspileProblem>(validationProblems.size());
         for (var problem : validationProblems) {
-            problems.add(new TranspileProblem(problem.code().name(), problem.message(), TranspileStage.VALIDATE));
+            problems.add(new TranspileProblem(
+                problem.code().name(),
+                problem.message(),
+                TranspileStage.VALIDATE,
+                null,
+                null,
+                null,
+                null,
+                problem.clausePath()
+            ));
         }
         return List.copyOf(problems);
     }

--- a/sqm-transpile/src/main/java/io/sqm/transpile/TranspileProblem.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/TranspileProblem.java
@@ -10,6 +10,7 @@ package io.sqm.transpile;
  * @param line one-based source line when the problem can be mapped to the input SQL
  * @param column one-based source column when the problem can be mapped to the input SQL
  * @param statementIndex optional one-based statement index when transpiling a statement sequence
+ * @param clausePath optional stable semantic path identifying the affected clause or relation
  */
 public record TranspileProblem(
     String code,
@@ -18,8 +19,32 @@ public record TranspileProblem(
     Integer sourceOffset,
     Integer line,
     Integer column,
-    Integer statementIndex
+    Integer statementIndex,
+    String clausePath
 ) {
+    /**
+     * Creates a transpile problem using the legacy coordinate and statement-index shape.
+     *
+     * @param code stable diagnostic code
+     * @param message human-readable problem description
+     * @param stage pipeline stage where the problem occurred
+     * @param sourceOffset zero-based source character offset when available
+     * @param line one-based source line when available
+     * @param column one-based source column when available
+     * @param statementIndex optional one-based statement index
+     */
+    public TranspileProblem(
+        String code,
+        String message,
+        TranspileStage stage,
+        Integer sourceOffset,
+        Integer line,
+        Integer column,
+        Integer statementIndex
+    ) {
+        this(code, message, stage, sourceOffset, line, column, statementIndex, null);
+    }
+
     /**
      * Creates a transpile problem without source coordinates.
      *
@@ -28,7 +53,7 @@ public record TranspileProblem(
      * @param stage pipeline stage where the problem occurred
      */
     public TranspileProblem(String code, String message, TranspileStage stage) {
-        this(code, message, stage, null, null, null, null);
+        this(code, message, stage, null, null, null, null, null);
     }
 
     /**
@@ -40,7 +65,7 @@ public record TranspileProblem(
      * @param sourceOffset zero-based source character offset when available
      */
     public TranspileProblem(String code, String message, TranspileStage stage, Integer sourceOffset) {
-        this(code, message, stage, sourceOffset, null, null, null);
+        this(code, message, stage, sourceOffset, null, null, null, null);
     }
 
     /**
@@ -54,7 +79,7 @@ public record TranspileProblem(
      * @param column one-based source column when available
      */
     public TranspileProblem(String code, String message, TranspileStage stage, Integer sourceOffset, Integer line, Integer column) {
-        this(code, message, stage, sourceOffset, line, column, null);
+        this(code, message, stage, sourceOffset, line, column, null, null);
     }
 
     /**
@@ -67,6 +92,6 @@ public record TranspileProblem(
         if (statementIndex < 1) {
             throw new IllegalArgumentException("statementIndex must be greater than zero");
         }
-        return new TranspileProblem(code, message, stage, sourceOffset, line, column, statementIndex);
+        return new TranspileProblem(code, message, stage, sourceOffset, line, column, statementIndex, clausePath);
     }
 }

--- a/sqm-transpile/src/main/java/io/sqm/transpile/TranspileRuleResult.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/TranspileRuleResult.java
@@ -102,12 +102,39 @@ public record TranspileRuleResult(
      * @return unsupported rule result
      */
     public static TranspileRuleResult unsupported(Statement statement, String code, String message) {
+        return unsupported(statement, code, message, null);
+    }
+
+    /**
+     * Creates an unsupported rule result with a stable semantic clause path.
+     *
+     * @param statement input statement
+     * @param code stable diagnostic code
+     * @param message human-readable problem description
+     * @param clausePath stable semantic path identifying the unsupported node
+     * @return unsupported rule result
+     */
+    public static TranspileRuleResult unsupported(
+        Statement statement,
+        String code,
+        String message,
+        String clausePath
+    ) {
         return new TranspileRuleResult(
             statement,
             false,
             RewriteFidelity.UNSUPPORTED,
             List.of(),
-            List.of(new TranspileProblem(code, message, TranspileStage.REWRITE)),
+            List.of(new TranspileProblem(
+                code,
+                message,
+                TranspileStage.REWRITE,
+                null,
+                null,
+                null,
+                null,
+                clausePath
+            )),
             message
         );
     }

--- a/sqm-transpile/src/main/java/io/sqm/transpile/builtin/MatchRecognizeUnsupportedRule.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/builtin/MatchRecognizeUnsupportedRule.java
@@ -1,0 +1,83 @@
+package io.sqm.transpile.builtin;
+
+import io.sqm.core.PatternRecognitionTable;
+import io.sqm.core.Statement;
+import io.sqm.core.dialect.SqlDialectId;
+import io.sqm.transpile.TranspileContext;
+import io.sqm.transpile.TranspileRuleResult;
+import io.sqm.transpile.rule.TranspileRule;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+/**
+ * Rejects row-pattern recognition unless a configured compatibility check proves
+ * that the complete modeled relation is preserved exactly.
+ */
+public final class MatchRecognizeUnsupportedRule implements TranspileRule {
+    private final BiPredicate<PatternRecognitionTable, TranspileContext> exactCompatibility;
+
+    /**
+     * Creates the default rule, which recognizes only Oracle-to-Oracle native
+     * preservation as exact.
+     */
+    public MatchRecognizeUnsupportedRule() {
+        this((table, context) ->
+            SqlDialectId.ORACLE.equals(context.sourceDialect())
+                && SqlDialectId.ORACLE.equals(context.targetDialect()));
+    }
+
+    /**
+     * Creates a rule with a compatibility hook for dialect integrations that can
+     * prove exact support for every modeled row-pattern option.
+     *
+     * @param exactCompatibility predicate receiving the relation and transpilation context
+     */
+    public MatchRecognizeUnsupportedRule(
+        BiPredicate<PatternRecognitionTable, TranspileContext> exactCompatibility
+    ) {
+        this.exactCompatibility = Objects.requireNonNull(exactCompatibility, "exactCompatibility");
+    }
+
+    @Override
+    public String id() {
+        return "match-recognize-unsupported";
+    }
+
+    @Override
+    public Set<SqlDialectId> sourceDialects() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<SqlDialectId> targetDialects() {
+        return Set.of();
+    }
+
+    @Override
+    public TranspileRuleResult apply(Statement statement, TranspileContext context) {
+        var relations = StatementFeatureInspector.patternRecognitionTables(statement);
+        if (relations.isEmpty()) {
+            return TranspileRuleResult.unchanged(statement, "No MATCH_RECOGNIZE relation detected");
+        }
+
+        var unsupported = relations.stream()
+            .filter(located -> !exactCompatibility.test(located.table(), context))
+            .findFirst();
+        if (unsupported.isEmpty()) {
+            return TranspileRuleResult.unchanged(statement, "MATCH_RECOGNIZE is preserved exactly");
+        }
+
+        var located = unsupported.orElseThrow();
+        var message = "MATCH_RECOGNIZE at " + located.path()
+            + " has no exact transpilation from " + context.sourceDialect().value()
+            + " to " + context.targetDialect().value();
+        return TranspileRuleResult.unsupported(
+            statement,
+            "UNSUPPORTED_MATCH_RECOGNIZE",
+            message,
+            located.path()
+        );
+    }
+}

--- a/sqm-transpile/src/main/java/io/sqm/transpile/builtin/StatementFeatureInspector.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/builtin/StatementFeatureInspector.java
@@ -3,6 +3,11 @@ package io.sqm.transpile.builtin;
 import io.sqm.core.*;
 import io.sqm.core.walk.RecursiveNodeVisitor;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -353,6 +358,10 @@ final class StatementFeatureInspector {
         return found.get();
     }
 
+    static List<LocatedPatternRecognition> patternRecognitionTables(Statement statement) {
+        return new PatternRecognitionLocationVisitor().find(statement);
+    }
+
     static boolean hasInsertMode(Statement statement, InsertStatement.InsertMode mode) {
         var found = new AtomicBoolean(false);
         statement.accept(new RecursiveNodeVisitor<Void>() {
@@ -389,5 +398,75 @@ final class StatementFeatureInspector {
             }
         });
         return found.get();
+    }
+
+    record LocatedPatternRecognition(PatternRecognitionTable table, String path) {
+    }
+
+    private static final class PatternRecognitionLocationVisitor extends RecursiveNodeVisitor<Void> {
+        private final ArrayDeque<String> segments = new ArrayDeque<>();
+        private final Map<String, Integer> occurrences = new LinkedHashMap<>();
+        private final List<LocatedPatternRecognition> located = new ArrayList<>();
+
+        List<LocatedPatternRecognition> find(Statement statement) {
+            accept(statement);
+            return List.copyOf(located);
+        }
+
+        @Override
+        protected Void defaultResult() {
+            return null;
+        }
+
+        @Override
+        protected Void accept(Node node) {
+            if (node == null) {
+                return null;
+            }
+            var segment = pathSegment(node);
+            if (segment != null) {
+                segments.addLast(segment);
+            }
+            try {
+                return node.accept(this);
+            }
+            finally {
+                if (segment != null) {
+                    segments.removeLast();
+                }
+            }
+        }
+
+        @Override
+        public Void visitPatternRecognitionTable(PatternRecognitionTable table) {
+            var basePath = String.join(".", segments);
+            var occurrence = occurrences.merge(basePath, 1, Integer::sum) - 1;
+            located.add(new LocatedPatternRecognition(table, basePath + "[" + occurrence + "]"));
+            return super.visitPatternRecognitionTable(table);
+        }
+
+        private static String pathSegment(Node node) {
+            return switch (node) {
+                case InsertStatement ignored -> "insert";
+                case UpdateStatement ignored -> "update";
+                case DeleteStatement ignored -> "delete";
+                case MergeStatement ignored -> "merge";
+                case SelectQuery ignored -> "select";
+                case CompositeQuery ignored -> "set";
+                case WithQuery ignored -> "with";
+                case CteDef ignored -> "cte";
+                case QueryTable ignored -> "queryTable";
+                case QueryExpr ignored -> "subquery";
+                case Join ignored -> "join";
+                case PatternRecognitionTable ignored -> "matchRecognize";
+                case Lateral ignored -> "lateral";
+                case PivotTable ignored -> "pivot";
+                case UnpivotTable ignored -> "unpivot";
+                case SampledTable ignored -> "sampled";
+                case JsonTable ignored -> "jsonTable";
+                case ExistsPredicate ignored -> "exists";
+                default -> null;
+            };
+        }
     }
 }

--- a/sqm-transpile/src/main/java/io/sqm/transpile/rule/DefaultTranspileRuleRegistry.java
+++ b/sqm-transpile/src/main/java/io/sqm/transpile/rule/DefaultTranspileRuleRegistry.java
@@ -54,6 +54,7 @@ public final class DefaultTranspileRuleRegistry implements TranspileRuleRegistry
             new PostgresToSqlServerReturningUnsupportedRule(),
             new SequenceValueUnsupportedRule(),
             new TableAccessModifierUnsupportedRule(),
+            new MatchRecognizeUnsupportedRule(),
             new PivotUnpivotApproximateRewriteRule(),
             new HierarchicalQueryToRecursiveCteRule(),
             new HierarchicalQueryUnsupportedRule(),

--- a/sqm-transpile/src/test/java/io/sqm/transpile/DefaultSqlTranspilerTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/DefaultSqlTranspilerTest.java
@@ -1757,6 +1757,47 @@ class DefaultSqlTranspilerTest {
         assertEquals("UNSUPPORTED_MYSQL_JSON_FUNCTION", result.problems().getFirst().code());
     }
 
+    @Test
+    void oracleMatchRecognizeIsRejectedBeforeNonOracleRenderingWithRelationPath() {
+        var transpiler = SqlTranspiler.builder()
+            .sourceDialect(SqlDialectId.ORACLE)
+            .targetDialect(SqlDialectId.POSTGRESQL)
+            .build();
+
+        var result = transpiler.transpile("""
+            SELECT *
+            FROM sales MATCH_RECOGNIZE (
+              PATTERN (A)
+              DEFINE A AS A.amount > 0
+            ) mr
+            """);
+
+        assertEquals(TranspileStatus.UNSUPPORTED, result.status());
+        assertTrue(result.sql().isEmpty());
+        assertEquals("UNSUPPORTED_MATCH_RECOGNIZE", result.problems().getFirst().code());
+        assertEquals("select.matchRecognize[0]", result.problems().getFirst().clausePath());
+    }
+
+    @Test
+    void oracleMatchRecognizeRemainsExactForOracleTargets() {
+        var transpiler = SqlTranspiler.builder()
+            .sourceDialect(SqlDialectId.ORACLE)
+            .targetDialect(SqlDialectId.ORACLE)
+            .build();
+
+        var result = transpiler.transpile("""
+            SELECT *
+            FROM sales MATCH_RECOGNIZE (
+              PATTERN (A)
+              DEFINE A AS A.amount > 0
+            ) mr
+            """);
+
+        assertEquals(TranspileStatus.SUCCESS, result.status());
+        assertTrue(normalizeSql(result.sql().orElseThrow()).contains("MATCH_RECOGNIZE"));
+        assertTrue(result.problems().isEmpty());
+    }
+
     private static TranspileRule approximateRule() {
         return new TranspileRule() {
             @Override

--- a/sqm-transpile/src/test/java/io/sqm/transpile/TranspileProblemTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/TranspileProblemTest.java
@@ -19,6 +19,7 @@ class TranspileProblemTest {
         assertEquals(1, problem.line());
         assertEquals(8, problem.column());
         assertNull(problem.statementIndex());
+        assertNull(problem.clausePath());
     }
 
     @Test
@@ -29,6 +30,7 @@ class TranspileProblemTest {
         assertNull(problem.line());
         assertNull(problem.column());
         assertNull(problem.statementIndex());
+        assertNull(problem.clausePath());
     }
 
     @Test
@@ -39,11 +41,15 @@ class TranspileProblemTest {
         assertNull(problem.line());
         assertNull(problem.column());
         assertNull(problem.statementIndex());
+        assertNull(problem.clausePath());
     }
 
     @Test
     void withStatementIndexCopiesProblemContext() {
-        var problem = new TranspileProblem("PARSE_ERROR", "Expected FROM", TranspileStage.PARSE, 7, 1, 8);
+        var problem = new TranspileProblem(
+            "PARSE_ERROR", "Expected FROM", TranspileStage.PARSE,
+            7, 1, 8, null, "select.matchRecognize[0]"
+        );
 
         var indexed = problem.withStatementIndex(2);
 
@@ -54,6 +60,7 @@ class TranspileProblemTest {
         assertEquals(problem.line(), indexed.line());
         assertEquals(problem.column(), indexed.column());
         assertEquals(2, indexed.statementIndex());
+        assertEquals(problem.clausePath(), indexed.clausePath());
     }
 
     @Test

--- a/sqm-transpile/src/test/java/io/sqm/transpile/TranspileProblemTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/TranspileProblemTest.java
@@ -45,6 +45,28 @@ class TranspileProblemTest {
     }
 
     @Test
+    void legacyConstructorStoresCoordinatesAndStatementIndexWithoutClausePath() {
+        var problem = new TranspileProblem(
+            "VALIDATION_ERROR",
+            "Unsupported clause",
+            TranspileStage.VALIDATE,
+            17,
+            2,
+            6,
+            3
+        );
+
+        assertEquals("VALIDATION_ERROR", problem.code());
+        assertEquals("Unsupported clause", problem.message());
+        assertEquals(TranspileStage.VALIDATE, problem.stage());
+        assertEquals(17, problem.sourceOffset());
+        assertEquals(2, problem.line());
+        assertEquals(6, problem.column());
+        assertEquals(3, problem.statementIndex());
+        assertNull(problem.clausePath());
+    }
+
+    @Test
     void withStatementIndexCopiesProblemContext() {
         var problem = new TranspileProblem(
             "PARSE_ERROR", "Expected FROM", TranspileStage.PARSE,

--- a/sqm-transpile/src/test/java/io/sqm/transpile/TranspileRuleResultTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/TranspileRuleResultTest.java
@@ -47,6 +47,9 @@ class TranspileRuleResultTest {
         var unsupported = TranspileRuleResult.unsupported(statement, "UNSUPPORTED", "No mapping");
         assertEquals(RewriteFidelity.UNSUPPORTED, unsupported.fidelity());
         assertEquals("UNSUPPORTED", unsupported.problems().getFirst().code());
+
+        var located = TranspileRuleResult.unsupported(statement, "LOCATED", "No mapping", "select.from");
+        assertEquals("select.from", located.problems().getFirst().clausePath());
     }
 
     @Test

--- a/sqm-transpile/src/test/java/io/sqm/transpile/builtin/MatchRecognizeUnsupportedRuleTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/builtin/MatchRecognizeUnsupportedRuleTest.java
@@ -1,0 +1,119 @@
+package io.sqm.transpile.builtin;
+
+import io.sqm.core.PatternRecognitionTable;
+import io.sqm.core.Statement;
+import io.sqm.core.dialect.SqlDialectId;
+import io.sqm.transpile.RewriteFidelity;
+import io.sqm.transpile.TranspileContext;
+import io.sqm.transpile.TranspileOptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.sqm.dsl.Dsl.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchRecognizeUnsupportedRuleTest {
+    @Test
+    void exposesGlobalRuntimeGuardShape() {
+        var rule = new MatchRecognizeUnsupportedRule();
+
+        assertEquals("match-recognize-unsupported", rule.id());
+        assertEquals(Set.of(), rule.sourceDialects());
+        assertEquals(Set.of(), rule.targetDialects());
+    }
+
+    @Test
+    void leavesStatementsWithoutPatternRecognitionUnchanged() {
+        var statement = select(col("id")).from(tbl("sales")).build();
+        var result = new MatchRecognizeUnsupportedRule()
+            .apply(statement, context(SqlDialectId.ORACLE, SqlDialectId.POSTGRESQL));
+
+        assertEquals(RewriteFidelity.EXACT, result.fidelity());
+        assertFalse(result.changed());
+        assertTrue(result.problems().isEmpty());
+    }
+
+    @Test
+    void preservesOracleNativeRelationsExactly() {
+        var statement = select(star()).from(patternRelation()).build();
+        var result = new MatchRecognizeUnsupportedRule()
+            .apply(statement, context(SqlDialectId.ORACLE, SqlDialectId.ORACLE));
+
+        assertEquals(RewriteFidelity.EXACT, result.fidelity());
+        assertFalse(result.changed());
+        assertTrue(result.problems().isEmpty());
+    }
+
+    @Test
+    void rejectsUnsupportedTargetWithStableTopLevelRelationPath() {
+        var statement = select(star()).from(patternRelation()).build();
+        var result = new MatchRecognizeUnsupportedRule()
+            .apply(statement, context(SqlDialectId.ORACLE, SqlDialectId.POSTGRESQL));
+
+        assertEquals(RewriteFidelity.UNSUPPORTED, result.fidelity());
+        var problem = result.problems().getFirst();
+        assertEquals("UNSUPPORTED_MATCH_RECOGNIZE", problem.code());
+        assertEquals("select.matchRecognize[0]", problem.clausePath());
+        assertTrue(problem.message().contains(problem.clausePath()));
+    }
+
+    @Test
+    void detectsNestedQueryJoinCteAndInsertSourceLocations() {
+        var nested = select(star())
+            .from(tbl(select(star()).from(patternRelation()).build()).as("nested"))
+            .build();
+        var joined = select(star())
+            .from(tbl("lookup").as("l"))
+            .join(inner(patternRelation()).on(col("l", "id").eq(col("mr", "id"))))
+            .build();
+        var cteQuery = with(cte("matches", select(star()).from(patternRelation()).build()))
+            .body(select(star()).from(tbl("matches")).build());
+        var insert = insert(tbl("match_archive"))
+            .columns(id("id"))
+            .query(select(col("id")).from(patternRelation()).build())
+            .build();
+
+        assertPath(nested, "select.queryTable.select.matchRecognize[0]");
+        assertPath(joined, "select.join.matchRecognize[0]");
+        assertPath(cteQuery, "with.cte.select.matchRecognize[0]");
+        assertPath(insert, "insert.select.matchRecognize[0]");
+    }
+
+    @Test
+    void customExactCompatibilityHookCanEnableFutureDialectPair() {
+        var future = SqlDialectId.of("future-pattern-sql");
+        var rule = new MatchRecognizeUnsupportedRule((table, context) ->
+            context.sourceDialect().equals(SqlDialectId.ORACLE)
+                && context.targetDialect().equals(future)
+                && table.subsets().isEmpty());
+        var result = rule.apply(
+            select(star()).from(patternRelation()).build(),
+            context(SqlDialectId.ORACLE, future)
+        );
+
+        assertEquals(RewriteFidelity.EXACT, result.fidelity());
+        assertTrue(result.problems().isEmpty());
+    }
+
+    private static void assertPath(Statement statement, String expectedPath) {
+        var result = new MatchRecognizeUnsupportedRule()
+            .apply(statement, context(SqlDialectId.ORACLE, SqlDialectId.MYSQL));
+
+        assertEquals(expectedPath, result.problems().getFirst().clausePath());
+    }
+
+    private static PatternRecognitionTable patternRelation() {
+        return matchRecognize(tbl("sales"))
+            .measure(matchNumber(), "match_no")
+            .pattern(patternVar("A"))
+            .define("A", patternColumn("A", "amount").gt(0))
+            .as("mr")
+            .build();
+    }
+
+    private static TranspileContext context(SqlDialectId source, SqlDialectId target) {
+        return new TranspileContext(source, target, TranspileOptions.defaults(), Optional.empty(), Optional.empty());
+    }
+}

--- a/sqm-transpile/src/test/java/io/sqm/transpile/rule/DefaultTranspileRuleRegistryDefaultsTest.java
+++ b/sqm-transpile/src/test/java/io/sqm/transpile/rule/DefaultTranspileRuleRegistryDefaultsTest.java
@@ -14,6 +14,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         assertEquals(
             java.util.List.of(
                 "function-table-to-mysql-unsupported",
+                "match-recognize-unsupported",
                 "postgres-merge-unsupported",
                 "postgres-to-mysql-distinct-on-unsupported",
                 "postgres-to-mysql-ilike",
@@ -36,6 +37,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
 
         assertEquals(
             java.util.List.of(
+                "match-recognize-unsupported",
                 "mysql-hint-dropping",
                 "mysql-to-postgres-insert-mode-unsupported",
                 "mysql-to-postgres-json-function-unsupported",
@@ -59,6 +61,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         assertEquals(
             java.util.List.of(
                 "hierarchical-query-unsupported",
+                "match-recognize-unsupported",
                 "postgres-merge-do-nothing-unsupported",
                 "postgres-to-sqlserver-distinct-on-unsupported",
                 "postgres-to-sqlserver-returning-unsupported",
@@ -70,6 +73,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         );
         assertEquals(
             java.util.List.of(
+                "match-recognize-unsupported",
                 "pivot-unpivot-approximate-rewrite",
                 "sqlserver-hint-dropping",
                 "sqlserver-merge-unsupported",
@@ -80,7 +84,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
             sqlServerToPostgresRules.stream().map(TranspileRule::id).sorted().toList()
         );
         assertEquals(
-            java.util.List.of("hierarchical-query-unsupported", "sequence-value-unsupported", "standard-limit-to-sqlserver-top", "table-access-modifier-unsupported"),
+            java.util.List.of("hierarchical-query-unsupported", "match-recognize-unsupported", "sequence-value-unsupported", "standard-limit-to-sqlserver-top", "table-access-modifier-unsupported"),
             ansiToSqlServerRules.stream().map(TranspileRule::id).sorted().toList()
         );
     }
@@ -98,6 +102,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
 
         assertEquals(
             java.util.List.of(
+                "match-recognize-unsupported",
                 "oracle-result-clause-unsupported",
                 "postgres-merge-do-nothing-unsupported",
                 "postgres-merge-not-matched-by-source-to-oracle-unsupported",
@@ -109,6 +114,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         assertEquals(
             java.util.List.of(
                 "hierarchical-query-to-recursive-cte",
+                "match-recognize-unsupported",
                 "oracle-hint-dropping",
                 "oracle-returning-into-unsupported",
                 "pivot-unpivot-approximate-rewrite",
@@ -118,6 +124,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         );
         assertEquals(
             java.util.List.of(
+                "match-recognize-unsupported",
                 "oracle-result-clause-unsupported",
                 "sqlserver-hint-dropping",
                 "sqlserver-merge-unsupported",
@@ -130,6 +137,7 @@ class DefaultTranspileRuleRegistryDefaultsTest {
         assertEquals(
             java.util.List.of(
                 "hierarchical-query-unsupported",
+                "match-recognize-unsupported",
                 "oracle-hint-dropping",
                 "oracle-returning-into-unsupported",
                 "oracle-to-sqlserver-pivot-unpivot-rule",


### PR DESCRIPTION
Closes #497. Adds path-aware transpilation diagnostics, exact-native compatibility handling, complete typed DSL codegen, golden compile/reconstruction tests, documentation, and an Oracle playground example. Local verification passed across the 26-module reactor; focused playground catalog and REST tests also passed.